### PR TITLE
Replace emoji library recommendation with JEmoji

### DIFF
--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -61,7 +61,7 @@ Didn't find an answer? Try asking in [our Discord server](https://discord.gg/0hM
 
     You can create instances of this for use in various methods, such as reactions, using the factory methods of the `Emoji` interface. For instance, to create a unicode emoji instance, you use `Emoji.fromUnicode("...")` with the string of **unicode characters**.
 
-    To get the Unicode char(s) of some Emoji, you can either use a 3rd party library (such as [emoji-java](https://github.com/MinnDevelopment/emoji-java)) or just look them up online.
+    To get the Unicode char(s) of some Emoji, you can either use a 3rd party library (such as [JEmoji](https://github.com/felldo/JEmoji)) or just look them up online.
     You can add reactions with 3 different formats:
 
     ```java

--- a/docs/using-jda/troubleshooting.md
+++ b/docs/using-jda/troubleshooting.md
@@ -67,7 +67,7 @@ NDkyNzQ3NzY5MDM2MDEzNTc4.Xw2cUA.LLslVBE1tfFK20sGsNm-FVFYdsA
 
 ### Can't get emoji from message
 
-Methods such as [`Mentions.getCustomEmojis()`](https://docs.jda.wiki/net/dv8tion/jda/api/entities/Mentions.html#getCustomEmojis()) and [`Mentions.getCustomEmojisBag()`](https://docs.jda.wiki/net/dv8tion/jda/api/entities/Mentions.html#getCustomEmojisBag()) only include custom emoji which have to be uploaded to a guild by a moderator. Unicode emoji such as 👍 are not included and require using a 3rd party library to be located in a string. You can use [emoji-java](https://github.com/MinnDevelopment/emoji-java) to extract unicode emoji from a message.
+Methods such as [`Mentions.getCustomEmojis()`](https://docs.jda.wiki/net/dv8tion/jda/api/entities/Mentions.html#getCustomEmojis()) and [`Mentions.getCustomEmojisBag()`](https://docs.jda.wiki/net/dv8tion/jda/api/entities/Mentions.html#getCustomEmojisBag()) only include custom emoji which have to be uploaded to a guild by a moderator. Unicode emoji such as 👍 are not included and require using a 3rd party library to be located in a string. You can use [JEmoji](https://github.com/felldo/JEmoji) to extract unicode emoji from a message.
 
 An example use-case including a code sample can be found in [this answer to a related question on StackOverflow](https://stackoverflow.com/a/58353912/10630900)
 


### PR DESCRIPTION
The emoji-java library is outdated. While this is promoting my own library, it is up to date and easily updatable because the emojis are auto generated, therefore I suggest to replace the current recommended one.